### PR TITLE
Revert "Run inline styles through prefixer"

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "array-flatten": "^2.1.0",
-    "has": "^1.0.1",
-    "inline-style-prefixer": "^2.0.0"
+    "has": "^1.0.1"
   }
 }

--- a/src/aphroditeInterface.js
+++ b/src/aphroditeInterface.js
@@ -2,7 +2,6 @@ import { StyleSheet, css } from 'aphrodite';
 import { flushToStyleTag } from 'aphrodite/lib/inject';
 import { from as flatten } from 'array-flatten';
 import has from 'has';
-import prefixAll from 'inline-style-prefixer/static';
 
 // This function takes the array of styles and separates them into styles that
 // are handled by Aphrodite and inline styles.
@@ -69,7 +68,7 @@ export default {
       result.className = css(...aphroditeStyles);
     }
     if (hasInlineStyles) {
-      result.style = prefixAll(inlineStyles);
+      result.style = inlineStyles;
     }
     return result;
   },

--- a/test/aphroditeInterface_test.js
+++ b/test/aphroditeInterface_test.js
@@ -104,25 +104,6 @@ describe('aphroditeInterface', () => {
         });
     });
 
-    it('prefixes inline styles', () => {
-      const style = {
-        display: 'flex',
-      };
-
-      expect(aphroditeInterface.resolve([style]))
-        .to.eql({
-          style: {
-            display: [
-              '-webkit-box',
-              '-moz-box',
-              '-ms-flexbox',
-              '-webkit-flex',
-              'flex',
-            ],
-          },
-        });
-    });
-
     it('handles a mix of Aphrodite and inline styles', () => {
       const styles = aphroditeInterface.create({
         foo: {


### PR DESCRIPTION
Reverts airbnb/react-with-styles-interface-aphrodite#2

Unfortunately, the prefixer doesn't always give us an object with a shape that is compatible with React's style prop--for example, when given `display: 'flex'`. We are exploring other options, but in the meantime, this needs to be reverted to prevent breaking folks.