### PR TITLE
Update tests for Aphrodite 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/airbnb/react-with-styles-interface-aphrodite#readme",
   "devDependencies": {
     "airbnb-js-shims": "^1.0.1",
-    "aphrodite": "^0.5.0",
+    "aphrodite": "^1.2.0",
     "babel-cli": "^6.18.0",
     "babel-preset-airbnb": "^2.1.1",
     "babel-register": "^6.18.0",

--- a/test/aphroditeInterfaceFactory_test.js
+++ b/test/aphroditeInterfaceFactory_test.js
@@ -25,7 +25,7 @@ describe('aphroditeInterfaceFactory', () => {
           _definition: {
             color: 'red',
           },
-          _name: 'foo_im3wl1',
+          _name: 'foo_137u7ef',
         },
       });
     });
@@ -40,7 +40,7 @@ describe('aphroditeInterfaceFactory', () => {
       });
 
       expect(aphroditeInterface.resolve([styles.foo]))
-        .to.eql({ className: 'foo_im3wl1' });
+        .to.eql({ className: 'foo_137u7ef' });
     });
 
     it('turns multiple processed styles into a className', () => {
@@ -55,7 +55,7 @@ describe('aphroditeInterfaceFactory', () => {
       });
 
       expect(aphroditeInterface.resolve([styles.foo, styles.bar]))
-        .to.eql({ className: 'foo_im3wl1-o_O-bar_cm9r68' });
+        .to.eql({ className: 'foo_137u7ef-o_O-bar_36rlri' });
     });
 
     it('handles an object with inline styles', () => {
@@ -119,7 +119,7 @@ describe('aphroditeInterfaceFactory', () => {
 
       expect(aphroditeInterface.resolve([styles.foo, style]))
         .to.eql({
-          className: 'foo_im3wl1',
+          className: 'foo_137u7ef',
           style: {
             display: 'inline-block',
           },
@@ -143,7 +143,7 @@ describe('aphroditeInterfaceFactory', () => {
 
       expect(aphroditeInterface.resolve([[styles.foo], [[styleA, styleB]]]))
         .to.eql({
-          className: 'foo_im3wl1',
+          className: 'foo_137u7ef',
           style: {
             display: 'inline-block',
             padding: 1,


### PR DESCRIPTION
In Aphrodite 1.2.0, we replaced the hashing algorithm for better
performance. This had the side-effect of changing the class names that
Aphrodite generates. For now I'm just going to update these to match.

This is an implementation detail of Aphrodite, so there's really nothing
else that we need to do to maintain compatibility.

Fixes #7.