### PR TITLE
Add RTL support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["airbnb"]
+  "presets": ["airbnb"],
+  "plugins": [
+    ["transform-replace-object-assign", "object.assign"],
+  ],
 }

--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ or when you need to [disable `!important`](https://github.com/Khan/aphrodite#dis
 ```js
 import aphroditeInterface from 'react-with-styles-interface-aphrodite/no-important';
 ```
+
+## Built-in RTL support
+
+`react-with-styles-interface-aphrodite` now has built-in RTL support. Specifically, it uses [rtl-css-js](https://github.com/kentcdodds/rtl-css-js) to automatically flip styles (`margin`, `padding`, `float`, `textAlign`, etc.) in a `dir="rtl"` context. We recommend using [react-with-direction](https://github.com/airbnb/react-with-direction)'s `DirectionProvider` at your top-level node to achieve best results.
+
+One caveat for this implementation is that it may cause some trouble when relying on inline styles explicitly. Due to some details of what is known at the time of style creation/resolution, inline styles are converted to classnames when there is a flippable style attribute. If you do not want this behavior or if this behavior breaks your usage, `react-with-styles-interface-aphrodite` exports a `resolveNoRTL` method which is exported by `react-with-styles` as `cssNoRTL`. This method matches the behavior in past versions (no automatic style flipping).

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "airbnb-js-shims": "^1.0.1",
     "aphrodite": "^1.2.0",
     "babel-cli": "^6.18.0",
+    "babel-plugin-transform-replace-object-assign": "^0.2.1",
     "babel-preset-airbnb": "^2.1.1",
     "babel-register": "^6.18.0",
     "chai": "^4.0.1",
@@ -60,6 +61,8 @@
   },
   "dependencies": {
     "array-flatten": "^2.1.0",
-    "has": "^1.0.1"
+    "has": "^1.0.1",
+    "object.assign": "^4.0.4",
+    "rtl-css-js": "^1.1.3"
   }
 }

--- a/src/aphroditeInterface.js
+++ b/src/aphroditeInterface.js
@@ -1,4 +1,5 @@
 import * as aphrodite from 'aphrodite';
 import aphroditeInterfaceFactory from './aphroditeInterfaceFactory';
+import withRTLExtension from './withRTLExtension';
 
-export default aphroditeInterfaceFactory(aphrodite);
+export default aphroditeInterfaceFactory(withRTLExtension(aphrodite));

--- a/src/generateRTLStyles.js
+++ b/src/generateRTLStyles.js
@@ -1,0 +1,52 @@
+import rtlCSSJS from 'rtl-css-js';
+import has from 'has';
+
+function stylesDiff(ltrStyles, rtlStyles) {
+  const ltrStylesDiff = { ...ltrStyles };
+
+  let hasRTLStyles = false;
+
+  const styles = {}; // only includes the necessary styles and overrides
+  Object.entries(rtlStyles)
+    .forEach(([key, value]) => {
+      if (has(ltrStylesDiff, key)) {
+        // We want ltrStylesDiff to only include the styles that need to be
+        // overridden because they had been flipped in such a way that they
+        // don't exist in the rtlStyles object. As such, we delete everything
+        // that exists in both rtlStyles and ltrStyles.
+        delete ltrStylesDiff[key];
+      }
+
+      if (value === ltrStyles[key]) {
+        return;
+      }
+
+      if (value && typeof value === 'object') {
+        // In some cases (pseudoselectors, matchmedia queries, etc.), the style
+        // value may be an object, and we need to recurse.
+        const recursiveStyles = stylesDiff(ltrStyles[key], value);
+        if (recursiveStyles != null) {
+          hasRTLStyles = true;
+          styles[key] = recursiveStyles;
+        }
+      } else if (value != null) {
+        hasRTLStyles = true;
+        styles[key] = value;
+      }
+    });
+
+  // The only styles remaining in ltrStylesDiff are those that have
+  // been flipped in such a way that they need to be reset in an RTL context.
+  Object.keys(ltrStylesDiff)
+    .forEach((key) => {
+      styles[key] = 'initial';
+    });
+
+  if (!hasRTLStyles) return null;
+
+  return styles;
+}
+
+export default function generateRTLStyles(ltrStyles) {
+  return stylesDiff(ltrStyles, rtlCSSJS(ltrStyles));
+}

--- a/src/no-important.js
+++ b/src/no-important.js
@@ -1,4 +1,5 @@
 import * as aphrodite from 'aphrodite/no-important';
 import aphroditeInterfaceFactory from './aphroditeInterfaceFactory';
+import withRTLExtension from './withRTLExtension';
 
-export default aphroditeInterfaceFactory(aphrodite);
+export default aphroditeInterfaceFactory(withRTLExtension(aphrodite));

--- a/src/withRTLExtension.js
+++ b/src/withRTLExtension.js
@@ -1,0 +1,28 @@
+export const RTL_SELECTOR = '_rtl';
+
+/*
+ * When automatically flipping CSS styles in our interface, instead of determining RTL/LTR context
+ * at the time of the create or resolve call (which is hard to do without either setting the
+ * direction in the global cache or ignoring inline styles entirely), we simply add a new style
+ * definition for the generated class name that is only applied in a [dir="rtl"] context. This
+ * handler adds that extra style definition to the <style /> tag created by Aphrodite.
+ */
+function directionSelectorHandler(selector, baseSelector, generateSubtreeStyles) {
+  if (selector !== RTL_SELECTOR) {
+    return null;
+  }
+
+  const generated = generateSubtreeStyles(baseSelector);
+
+  // generated may include more than one style definition. We want to prefix each one individually.
+  // This primarily happens for pseudo selectors for which generated looks like
+  //   .classname::selector{...}.classname::otherselector{...}
+  // This is the only case we really worry about, and as a result, we split on '}.' which marks the
+  // end of style definition and beginning of a new one.
+  const styleDefs = generated.split('}.').map(g => `[dir="rtl"] ${g}`);
+  return styleDefs.join('}.');
+}
+
+export default function withRTLExtension({ StyleSheet } /* aphrodite */) {
+  return StyleSheet.extend([{ selectorHandler: directionSelectorHandler }]);
+}

--- a/test/aphroditeInterfaceFactory_test.js
+++ b/test/aphroditeInterfaceFactory_test.js
@@ -150,5 +150,148 @@ describe('aphroditeInterfaceFactory', () => {
           },
         });
     });
+
+    it('converts inline styles to a className when there are RTL styles', () => {
+      const style = {
+        marginLeft: 10,
+      };
+
+      expect(aphroditeInterface.resolve([style]))
+        .to.eql({ className: 'inlineStyles_15cjgmo' });
+    });
+  });
+
+  describe('.resolveNoRTL()', () => {
+    it('turns a processed style into a className', () => {
+      const styles = aphroditeInterface.create({
+        foo: {
+          color: 'red',
+        },
+      });
+
+      expect(aphroditeInterface.resolveNoRTL([styles.foo]))
+        .to.eql({ className: 'foo_137u7ef' });
+    });
+
+    it('turns multiple processed styles into a className', () => {
+      const styles = aphroditeInterface.create({
+        foo: {
+          color: 'red',
+        },
+
+        bar: {
+          display: 'inline-block',
+        },
+      });
+
+      expect(aphroditeInterface.resolveNoRTL([styles.foo, styles.bar]))
+        .to.eql({ className: 'foo_137u7ef-o_O-bar_36rlri' });
+    });
+
+    it('handles an object with inline styles', () => {
+      const style = {
+        color: 'red',
+      };
+
+      expect(aphroditeInterface.resolveNoRTL([style]))
+        .to.eql({
+          style: {
+            color: 'red',
+          },
+        });
+    });
+
+    it('does not convert to className even for RTL-flippable inline styles', () => {
+      const style = {
+        marginLeft: 10,
+      };
+
+      expect(aphroditeInterface.resolveNoRTL([style]))
+        .to.eql({
+          style: {
+            marginLeft: 10,
+          },
+        });
+    });
+
+    it('handles multiple objects with inline styles', () => {
+      const styleA = {
+        color: 'red',
+      };
+
+      const styleB = {
+        display: 'inline-block',
+      };
+
+      expect(aphroditeInterface.resolveNoRTL([styleA, styleB]))
+        .to.eql({
+          style: {
+            color: 'red',
+            display: 'inline-block',
+          },
+        });
+    });
+
+    it('prefers inline styles from later arguments', () => {
+      const styleA = {
+        color: 'red',
+      };
+
+      const styleB = {
+        color: 'blue',
+      };
+
+      expect(aphroditeInterface.resolveNoRTL([styleA, styleB]))
+        .to.eql({
+          style: {
+            color: 'blue',
+          },
+        });
+    });
+
+    it('handles a mix of Aphrodite and inline styles', () => {
+      const styles = aphroditeInterface.create({
+        foo: {
+          color: 'red',
+        },
+      });
+
+      const style = {
+        display: 'inline-block',
+      };
+
+      expect(aphroditeInterface.resolveNoRTL([styles.foo, style]))
+        .to.eql({
+          className: 'foo_137u7ef',
+          style: {
+            display: 'inline-block',
+          },
+        });
+    });
+
+    it('handles nested arrays', () => {
+      const styles = aphroditeInterface.create({
+        foo: {
+          color: 'red',
+        },
+      });
+
+      const styleA = {
+        display: 'inline-block',
+      };
+
+      const styleB = {
+        padding: 1,
+      };
+
+      expect(aphroditeInterface.resolveNoRTL([[styles.foo], [[styleA, styleB]]]))
+        .to.eql({
+          className: 'foo_137u7ef',
+          style: {
+            display: 'inline-block',
+            padding: 1,
+          },
+        });
+    });
   });
 });

--- a/test/aphroditeInterface_test.js
+++ b/test/aphroditeInterface_test.js
@@ -16,6 +16,7 @@ describe('aphroditeInterface', () => {
   it('is an interface', () => {
     expect(typeof aphroditeInterface.create).to.equal('function');
     expect(typeof aphroditeInterface.resolve).to.equal('function');
+    expect(typeof aphroditeInterface.resolveNoRTL).to.equal('function');
   });
 
   it('uses !important', () => {

--- a/test/generateRTLStyles_test.js
+++ b/test/generateRTLStyles_test.js
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+
+import generateRTLStyles from '../src/generateRTLStyles';
+
+describe('#generateRTLStyles', () => {
+  it('returns null for non-flippable styles', () => {
+    const ltrStyles = {
+      color: 'red',
+    };
+
+    expect(generateRTLStyles(ltrStyles)).to.eql(null);
+  });
+
+  it('returns flipped style if value were to change', () => {
+    const ltrStyles = {
+      textAlign: 'left',
+    };
+
+    expect(generateRTLStyles(ltrStyles)).to.eql({
+      textAlign: 'right',
+    });
+  });
+
+  it('returns flipped style and override if style key changes', () => {
+    const ltrStyles = {
+      marginLeft: 10,
+    };
+
+    expect(generateRTLStyles(ltrStyles)).to.eql({
+      marginLeft: 'initial',
+      marginRight: 10,
+    });
+  });
+
+  it('handles nested objects', () => {
+    const ltrStyles = {
+      ':before': {
+        left: 10,
+        color: 'red',
+      },
+      ':after': {
+        float: 'right',
+      },
+    };
+
+    expect(generateRTLStyles(ltrStyles)).to.eql({
+      ':before': {
+        left: 'initial',
+        right: 10,
+      },
+      ':after': {
+        float: 'left',
+      },
+    });
+  });
+});

--- a/test/no-imporant_test.js
+++ b/test/no-imporant_test.js
@@ -16,6 +16,7 @@ describe('no-important', () => {
   it('is an interface', () => {
     expect(typeof aphroditeInterface.create).to.equal('function');
     expect(typeof aphroditeInterface.resolve).to.equal('function');
+    expect(typeof aphroditeInterface.resolveNoRTL).to.equal('function');
   });
 
   it('does not use !important', () => {


### PR DESCRIPTION
This PR adds automatic RTL support to the Aphrodite interface by leveraging the `rtl-css-js` as well as Aphrodite's plugin API. 

This change will require https://github.com/airbnb/react-with-styles/pull/95 to work properly.

I've tested this in one of our repos and it works as expected.

@lencioni @ljharb @yzimet @airbnb/webinfra could y'all take a look?

Still TODO:
- [X] Write tests
- [X] Get `no-important` working with RTL support