### PR TITLE
[deps] bump rtl-css-js to include upstream features

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "array-flatten": "^2.1.0",
     "has": "^1.0.1",
     "object.assign": "^4.0.4",
-    "rtl-css-js": "^1.1.3"
+    "rtl-css-js": "^1.3.0"
   }
 }


### PR DESCRIPTION
This PR increases the version of `rtl-css-js` in order to include flipping of:
- borderLeftWidth
- translateX, translate, translate3d

cc: @majapw 