### PR TITLE
[deps] bump the rtl-css-js package to v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "array-flatten": "^2.1.0",
     "has": "^1.0.1",
     "object.assign": "^4.0.4",
-    "rtl-css-js": "^1.3.0"
+    "rtl-css-js": "^1.4.0"
   }
 }


### PR DESCRIPTION
This PR increases the version of `rtl-css-js` in order to include flipping of:
- linear-gradient

This is probably semver minor.

to: @majapw @ljharb @lencioni 