### PR TITLE
Only call generateDirectionalStyles *once* for every StyleSheet definition

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,11 @@
 {
   "extends": "airbnb",
-
   "env": {
     "browser": true,
     "node": true
+  },
+
+  "rules": {
+    "no-underscore-dangle": 0
   }
 }

--- a/src/utils/resolve.js
+++ b/src/utils/resolve.js
@@ -3,6 +3,13 @@ import { from as flatten } from 'array-flatten';
 
 import separateStyles from './separateStyles';
 
+function resetStyleDefinition(stylesObj) {
+  if (stylesObj.noRTL) {
+    stylesObj._definition = stylesObj.noRTL;
+  }
+  return stylesObj;
+}
+
 // Styles is an array of properties returned by `create()`, a POJO, or an
 // array thereof. POJOs are treated as inline styles. This version of the
 // resolve function explicitly does no work to flip styles for an RTL context.
@@ -14,13 +21,7 @@ export default function resolve(css, styles) {
     aphroditeStyles,
     hasInlineStyles,
     inlineStyles,
-  } = separateStyles(flattenedStyles);
-
-  aphroditeStyles.forEach((stylesObj) => {
-    if (stylesObj.noRTL) {
-      stylesObj._definition = stylesObj.noRTL;
-    }
-  });
+  } = separateStyles(flattenedStyles, resetStyleDefinition);
 
   const result = {};
   if (aphroditeStyles.length > 0) {

--- a/src/utils/resolve.js
+++ b/src/utils/resolve.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import { from as flatten } from 'array-flatten';
 
 import separateStyles from './separateStyles';
@@ -14,6 +15,12 @@ export default function resolve(css, styles) {
     hasInlineStyles,
     inlineStyles,
   } = separateStyles(flattenedStyles);
+
+  aphroditeStyles.forEach((stylesObj) => {
+    if (stylesObj.noRTL) {
+      stylesObj._definition = stylesObj.noRTL;
+    }
+  });
 
   const result = {};
   if (aphroditeStyles.length > 0) {

--- a/src/utils/resolveWithRTL.js
+++ b/src/utils/resolveWithRTL.js
@@ -5,6 +5,22 @@ import { hashObject } from 'aphrodite/lib/util';
 import separateStyles from './separateStyles';
 import generateDirectionalStyles from './generateDirectionalStyles';
 
+function setStyleDefinitionWithRTL(stylesObj) {
+  // Since we are mutating the StyleSheet object directly, we want to cache the withRTL/noRTL
+  // results and then set the _definition key to point to the appropriate version when necessary.
+  if (!stylesObj.withRTL || !stylesObj.noRTL) {
+    // The _definition key is an implementation detail of aphrodite. If aphrodite
+    // changes it in the future, this code will need to be updated.
+    const definition = stylesObj._definition;
+    stylesObj.noRTL = definition;
+
+    const directionalStyles = generateDirectionalStyles(definition);
+    stylesObj.withRTL = directionalStyles || definition;
+  }
+  stylesObj._definition = stylesObj.withRTL;
+  return stylesObj;
+}
+
 // Styles is an array of properties returned by `create()`, a POJO, or an
 // array thereof. POJOs are treated as inline styles. The default resolve
 // method makes an effort to flip CSS styles for an RTL context.
@@ -16,22 +32,7 @@ export default function resolveWithRTL(css, styles) {
     aphroditeStyles,
     hasInlineStyles,
     inlineStyles,
-  } = separateStyles(flattenedStyles);
-
-  aphroditeStyles.forEach((stylesObj) => {
-    // Since we are mutating the StyleSheet object directly, we want to cache the withRTL/noRTL
-    // results and then set the _definition key to point to the appropriate version when necessary.
-    if (!stylesObj.withRTL || !stylesObj.noRTL) {
-      // The _definition key is an implementation detail of aphrodite. If aphrodite
-      // changes it in the future, this code will need to be updated.
-      const definition = stylesObj._definition;
-      stylesObj.noRTL = definition;
-
-      const directionalStyles = generateDirectionalStyles(definition);
-      stylesObj.withRTL = directionalStyles || definition;
-    }
-    stylesObj._definition = stylesObj.withRTL;
-  });
+  } = separateStyles(flattenedStyles, setStyleDefinitionWithRTL);
 
   const result = {};
   if (hasInlineStyles) {

--- a/src/utils/separateStyles.js
+++ b/src/utils/separateStyles.js
@@ -2,7 +2,7 @@ import has from 'has';
 
 // This function takes the array of styles and separates them into styles that
 // are handled by Aphrodite and inline styles.
-export default function separateStyles(stylesArray) {
+export default function separateStyles(stylesArray, aphroditeStyleTransform) {
   const aphroditeStyles = [];
 
   // Since determining if an Object is empty requires collecting all of its
@@ -15,7 +15,7 @@ export default function separateStyles(stylesArray) {
   // performance is critical. Normally we would prefer using `forEach`, but
   // old-fashioned for loops are faster so that's what we have chosen here.
   for (let i = 0; i < stylesArray.length; i += 1) {
-    const style = stylesArray[i];
+    let style = stylesArray[i];
 
     // If this  style is falsey, we just want to disregard it. This allows for
     // syntax like:
@@ -28,6 +28,10 @@ export default function separateStyles(stylesArray) {
       ) {
         // This looks like a reference to an Aphrodite style object, so that's
         // where it goes.
+        if (aphroditeStyleTransform) {
+          style = aphroditeStyleTransform(style);
+        }
+
         aphroditeStyles.push(style);
       } else {
         Object.assign(inlineStyles, style);

--- a/test/utils/generateDirectionalStyles_test.js
+++ b/test/utils/generateDirectionalStyles_test.js
@@ -79,4 +79,34 @@ describe('#generateDirectionalStyles', () => {
       },
     });
   });
+
+  it('handles shared nested shared style with flipped style', () => {
+    const originalStyles = {
+      container: {
+        textAlign: 'left',
+        ':active': {
+          outline: 0,
+        },
+      },
+    };
+
+    expect(generateDirectionalStyles(originalStyles))
+      .to.eql({
+        container: {
+          ':active': {
+            outline: 0,
+          },
+        },
+        _ltr: {
+          container: {
+            textAlign: 'left',
+          },
+        },
+        _rtl: {
+          container: {
+            textAlign: 'right',
+          },
+        },
+      });
+  });
 });

--- a/test/utils/resolveWithRTL_test.js
+++ b/test/utils/resolveWithRTL_test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import aphrodite from 'aphrodite';
 
 import withRTLExtension from '../../src/utils/withRTLExtension';
+import resolve from '../../src/utils/resolve';
 import resolveWithRTL from '../../src/utils/resolveWithRTL';
 
 const { StyleSheetTestUtils, StyleSheet, css } = withRTLExtension(aphrodite);
@@ -140,5 +141,43 @@ describe('#resolveWithRTL', () => {
           padding: 1,
         },
       });
+  });
+
+  it('handles multiple calls to the same style definition', () => {
+    const styles = StyleSheet.create({
+      container: {
+        textAlign: 'left',
+      },
+    });
+
+    resolveWithRTL(css, [styles.container]);
+    const definition = { ...styles.container._definition };
+
+    resolveWithRTL(css, [styles.container]);
+    const newDefinition = styles.container._definition;
+    expect(definition).to.eql(newDefinition);
+  });
+
+  it('style definition is as expected even after calling resolveWithRTL', () => {
+    const styles = StyleSheet.create({
+      container: {
+        textAlign: 'left',
+      },
+    });
+
+    resolve(css, [styles.container]);
+    const oldDefinition = { ...styles.container._definition };
+
+    resolveWithRTL(css, [styles.container]);
+    const definition = styles.container._definition;
+    expect(definition).to.not.eql(oldDefinition);
+    expect(definition).to.eql({
+      _ltr: {
+        textAlign: 'left',
+      },
+      _rtl: {
+        textAlign: 'right',
+      },
+    });
   });
 });

--- a/test/utils/resolve_test.js
+++ b/test/utils/resolve_test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { StyleSheetTestUtils, StyleSheet, css } from 'aphrodite';
 
+import resolveWithRTL from '../../src/utils/resolveWithRTL';
 import resolve from '../../src/utils/resolve';
 
 describe('#resolve', () => {
@@ -131,5 +132,38 @@ describe('#resolve', () => {
           padding: 1,
         },
       });
+  });
+
+  it('handles multiple calls to the same style definition', () => {
+    const styles = StyleSheet.create({
+      container: {
+        textAlign: 'left',
+      },
+    });
+
+    resolve(css, [styles.container]);
+    const definition = { ...styles.container._definition };
+
+    resolve(css, [styles.container]);
+    const newDefinition = styles.container._definition;
+    expect(definition).to.eql(newDefinition);
+  });
+
+  it('style definition is as expected even after calling resolveWithRTL', () => {
+    const styles = StyleSheet.create({
+      container: {
+        textAlign: 'left',
+      },
+    });
+
+    resolveWithRTL(css, [styles.container]);
+    const oldDefinition = { ...styles.container._definition };
+
+    resolve(css, [styles.container]);
+    const definition = styles.container._definition;
+    expect(definition).to.not.eql(oldDefinition);
+    expect(definition).to.eql({
+      textAlign: 'left',
+    });
   });
 });


### PR DESCRIPTION
When I attempted to use v3.0.0 of RWS-IA in production, I found a very interesting bug. Namely, our Storybook (which has hundreds of calls to the RWS's CSS method) was essentially not loading (it felt like the browser was hanging). I sliced it in such a way so that only one component's story was being rendered and tried to delve deeper into what styles were actually being applied. Upon investigation, it looked like the recursive portion of `generateDirectionalStyles` was running infinitely:
<img width="471" alt="screen shot 2017-09-12 at 6 38 11 pm" src="https://user-images.githubusercontent.com/1383861/30493296-6ee13e5a-99f8-11e7-8218-28d09aa3edc0.png">

When I ran the same style definition in tests here, it seemed to work as expected so I was confused.

The tl;dr is that for low-level components in our library (`Link`, `Text`, `Button`), `generateDirectionStyles` was running quite a lot, and on each run, it was adding a layer to the `_ltr` and `_rtl` objects in the style. One of the optimizations we did in a last pass in https://github.com/airbnb/react-with-styles-interface-aphrodite/pull/18 was *not* to create a new object when looking at the `aphroditeStyles` passed in. Instead, we called `generateDirectionalStyles` on the definition and then applied the result directly to the aphrodite styles object. This passed all the tests we had at that time.

The problem was that we would repeatedly call `generateDirectionalStyles` on the updated styles object and the `_ltr`/`_rtl` keys would be treated like normal nested styles (pseudoselectors, match media queries, etc). This PR only calls the method once per style def and then caches the results, selecting the correct one based on whether or not `resolve` or `resolveNoRTL` is called.

This change *only* affects the `with-rtl` interface.

to: @ljharb @gabergg @yzimet @lencioni 