### PR TITLE
[RFC] Add fix for differing specificity between flippable and non-flippable versions of the same style

### DIFF
--- a/src/utils/generateDirectionalStyles.js
+++ b/src/utils/generateDirectionalStyles.js
@@ -2,11 +2,13 @@ import rtlCSSJS from 'rtl-css-js';
 
 import { LTR_SELECTOR, RTL_SELECTOR } from './withRTLExtension';
 
+const directionRegex = /Left|Right/;
+
 function isEmpty(obj) {
   return obj && Object.keys(obj).length === 0;
 }
 
-function separateDirectionalStyles(originalStyles, autoRTLStyles) {
+function separateDirectionalStyles(originalStyles, autoRTLStyles, directionalStyleKeys) {
   const sharedStyles = {};
   const ltrStyles = { ...originalStyles };
   const rtlStyles = {};
@@ -24,7 +26,8 @@ function separateDirectionalStyles(originalStyles, autoRTLStyles) {
         delete ltrStyles[key];
         // In some cases (pseudoselectors, matchmedia queries, etc.), the style
         // value may be an object, and we need to recurse.
-        const recursiveStyles = separateDirectionalStyles(originalStyles[key], value);
+        const recursiveStyles =
+          separateDirectionalStyles(originalStyles[key], value, directionalStyleKeys);
 
         if (recursiveStyles != null) {
           hasRTLStyles = true;
@@ -34,6 +37,7 @@ function separateDirectionalStyles(originalStyles, autoRTLStyles) {
             rtlStyles: recursiveRtlStyles,
           } = recursiveStyles;
 
+          directionalStyleKeys.add(key.replace(directionRegex, ''));
           if (recursiveSharedStyles) sharedStyles[key] = recursiveSharedStyles;
           if (recursiveLtrStyles) ltrStyles[key] = recursiveLtrStyles;
           if (recursiveRtlStyles) rtlStyles[key] = recursiveRtlStyles;
@@ -43,6 +47,7 @@ function separateDirectionalStyles(originalStyles, autoRTLStyles) {
       } else if (value != null) {
         hasRTLStyles = true;
         rtlStyles[key] = value;
+        directionalStyleKeys.add(key.replace(directionRegex, ''));
       }
     });
 
@@ -55,8 +60,12 @@ function separateDirectionalStyles(originalStyles, autoRTLStyles) {
   };
 }
 
-export default function generateDirectionalStyles(originalStyles) {
-  const directionalStyles = separateDirectionalStyles(originalStyles, rtlCSSJS(originalStyles));
+export default function generateDirectionalStyles(
+  originalStyles,
+  directionalStyleKeys = new Set(),
+) {
+  const directionalStyles =
+    separateDirectionalStyles(originalStyles, rtlCSSJS(originalStyles), directionalStyleKeys);
   if (!directionalStyles) return null;
 
   const { sharedStyles, ltrStyles, rtlStyles } = directionalStyles;

--- a/test/utils/resolveWithRTL_test.js
+++ b/test/utils/resolveWithRTL_test.js
@@ -180,4 +180,22 @@ describe('#resolveWithRTL', () => {
       },
     });
   });
+
+
+  it('style specificity', () => {
+    const styles = StyleSheet.create({
+      foo: {
+        marginLeft: 10,
+        float: 'right',
+      },
+
+      bar: {
+        margin: 0,
+        float: 'none',
+      },
+    });
+
+    expect(resolveWithRTL(css, [styles.foo, styles.bar]))
+      .to.eql({ className: 'foo_mzo4yj-o_O-bar_1v47723' });
+  });
 });


### PR DESCRIPTION
This is an incomplete prototype of an idea I've been mulling about in my head for a while.

Basically, if you are relying on overriding a directional style (`borderLeft/Right`, `paddingLeft/Right`, `marginLeft/Right`, `translateX(100))` with a non-directional style (`border`, `padding`, `margin`, `translateX(0)`), the specificity of the directional style will always win and this will probably cause a bug.

While this solution is incomplete (does not cover recursive styles very well rn), I wanted to get some feedback. The more I think about this, the more it might make sense to just get rid of shared styles entirely. It would fix the specificity problem and while it would bloat the page a little by duplicating some injected styles, it would be a much simpler process of generation and the cost may be recuped there.

Thoughts? 

@yzimet @lencioni @ljharb @garrettberg @jasonkb
