### PR TITLE
Fix `this` references inside the aphroditeInterfaceFactory

### DIFF
--- a/src/aphroditeInterfaceFactory.js
+++ b/src/aphroditeInterfaceFactory.js
@@ -7,7 +7,7 @@ import resolveRTL from './utils/resolveRTL';
 
 export default ({ StyleSheet, css }/* aphrodite */) => ({
   create(styleHash) {
-    return this.createLTR(styleHash);
+    return StyleSheet.create(styleHash);
   },
 
   createLTR(styleHash) {
@@ -24,7 +24,7 @@ export default ({ StyleSheet, css }/* aphrodite */) => ({
   },
 
   resolve(styles) {
-    return this.resolveLTR(styles);
+    return resolveLTR(css, styles);
   },
 
   resolveLTR(styles) {


### PR DESCRIPTION
Due to the fact that `aphroditeInterfaceFactory` returns an arrow function, `this` did not reference what we expected it to and the attempts to have create reference the createLTR method (same for resolve and resolveLTR) were terribly broken.

It's unclear as to why this didn't break tests here and only became an issue when I was attempting to import this library elsewhere.

to: @ljharb @lencioni 