### PR TITLE
Improve tree-shakeability of Aphrodite, drop support for v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/airbnb/react-with-styles-interface-aphrodite#readme",
   "devDependencies": {
     "airbnb-js-shims": "^1.4.0",
-    "aphrodite": "^1.2.5",
+    "aphrodite": "^2.1.0",
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-replace-object-assign": "^0.2.1",
     "babel-preset-airbnb": "^2.4.0",
@@ -63,7 +63,7 @@
     "sinon-sandbox": "^1.0.2"
   },
   "peerDependencies": {
-    "aphrodite": ">=0.5.0",
+    "aphrodite": "^2.1.0",
     "react-with-styles": "^3.0.0"
   },
   "dependencies": {

--- a/src/aphroditeInterface.js
+++ b/src/aphroditeInterface.js
@@ -1,7 +1,8 @@
-import { StyleSheet, css } from 'aphrodite';
+import { StyleSheet, css, flushToStyleTag } from 'aphrodite';
 import aphroditeInterfaceFactory from './aphroditeInterfaceFactory';
 
 export default aphroditeInterfaceFactory({
   StyleSheet,
   css,
+  flushToStyleTag,
 });

--- a/src/aphroditeInterfaceFactory.js
+++ b/src/aphroditeInterfaceFactory.js
@@ -4,18 +4,7 @@ import entries from 'object.entries';
 import resolveLTR from './utils/resolveLTR';
 import resolveRTL from './utils/resolveRTL';
 
-let flushToStyleTag;
-try {
-  // Aphrodite 1
-  // eslint-disable-next-line import/no-unresolved, global-require, prefer-destructuring
-  flushToStyleTag = require('aphrodite/lib/inject').flushToStyleTag;
-} catch (e) {
-  // Aphrodite 2
-  // eslint-disable-next-line import/no-unresolved, global-require, prefer-destructuring
-  flushToStyleTag = require('aphrodite').flushToStyleTag;
-}
-
-export default ({ StyleSheet, css }/* aphrodite */) => ({
+export default ({ StyleSheet, css, flushToStyleTag }/* aphrodite */) => ({
   create(styleHash) {
     return StyleSheet.create(styleHash);
   },

--- a/src/no-important.js
+++ b/src/no-important.js
@@ -1,7 +1,8 @@
-import { StyleSheet, css } from 'aphrodite/no-important';
+import { StyleSheet, css, flushToStyleTag } from 'aphrodite/no-important';
 import aphroditeInterfaceFactory from './aphroditeInterfaceFactory';
 
 export default aphroditeInterfaceFactory({
   StyleSheet,
   css,
+  flushToStyleTag,
 });

--- a/test/aphroditeInterfaceFactory_test.js
+++ b/test/aphroditeInterfaceFactory_test.js
@@ -1,21 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon-sandbox';
-import { StyleSheet, css, StyleSheetTestUtils } from 'aphrodite';
+import { StyleSheet, css, flushToStyleTag, StyleSheetTestUtils } from 'aphrodite';
 import aphroditeInterfaceFactory from '../src/aphroditeInterfaceFactory';
 
 import * as resolveLTR from '../src/utils/resolveLTR';
 import * as resolveRTL from '../src/utils/resolveRTL';
-
-let flushToStyleTag;
-try {
-  // Aphrodite 1
-  // eslint-disable-next-line import/no-unresolved, global-require, prefer-destructuring
-  flushToStyleTag = require('aphrodite/lib/inject').flushToStyleTag;
-} catch (e) {
-  // Aphrodite 2
-  // eslint-disable-next-line import/no-unresolved, global-require, prefer-destructuring
-  flushToStyleTag = require('aphrodite').flushToStyleTag;
-}
 
 describe('aphroditeInterfaceFactory', () => {
   const aphroditeInterface = aphroditeInterfaceFactory({


### PR DESCRIPTION

I originally added support for Aphrodite v2 in a backwards-compatible
way, but had to resort to using CommonJS in a try/catch to make it work.
This will make Aphrodite less tree-shakeable than using the named
export, so I want to get things on that now. This means we have to drop
support for v1, making this a breaking change.

v2 now uses ES modules with named exports, and exposes flushToStyleTag
explicitly instead of requiring a deep import.

More info: https://twitter.com/lencioni/status/974161112110280704