### PR TITLE
Replace array-flatten with array.prototype.flat

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-with-styles": "^3.0.0"
   },
   "dependencies": {
-    "array-flatten": "^2.1.1",
+    "array.prototype.flat": "^1.2.1",
     "has": "^1.0.3",
     "object.assign": "^4.1.0",
     "object.entries": "^1.0.4",

--- a/src/utils/resolveLTR.js
+++ b/src/utils/resolveLTR.js
@@ -1,4 +1,4 @@
-import { from as flatten } from 'array-flatten';
+import flat from 'array.prototype.flat';
 
 import separateStyles from './separateStyles';
 
@@ -7,7 +7,7 @@ import separateStyles from './separateStyles';
 // resolve function explicitly does no work to flip styles for an RTL context.
 // This function returns an object to be spread onto an element.
 export default function resolveLTR(css, styles) {
-  const flattenedStyles = flatten(styles);
+  const flattenedStyles = flat(styles, Infinity);
 
   const {
     aphroditeStyles,

--- a/src/utils/resolveRTL.js
+++ b/src/utils/resolveRTL.js
@@ -1,4 +1,4 @@
-import { from as flatten } from 'array-flatten';
+import flat from 'array.prototype.flat';
 import rtlCSSJS from 'rtl-css-js';
 
 import separateStyles from './separateStyles';
@@ -8,7 +8,7 @@ import separateStyles from './separateStyles';
 // resolve function explicitly flips inline styles for an RTL context.
 // This function returns an object to be spread onto an element.
 export default function resolveRTL(css, styles) {
-  const flattenedStyles = flatten(styles);
+  const flattenedStyles = flat(styles, Infinity);
 
   const {
     aphroditeStyles,


### PR DESCRIPTION
This is the shim package for the standard Array.prototype.flat, so this
will use the native function in environments where it is available.

Since we might have deeply nested arrays, I decided to pass flat a depth
of Infinity. Looking at the test suite, this seems to be the correct way
to accomplish this:

  https://github.com/es-shims/Array.prototype.flat/blob/0bb5b417/test/tests.js#L19