### PR TITLE
[deps] Update all deps and drop support for node < 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "10"
   - "8"
   - "6"
-  - "4"
 before_install:
   - 'nvm install-latest-npm'
 install:

--- a/package.json
+++ b/package.json
@@ -40,27 +40,28 @@
   },
   "homepage": "https://github.com/airbnb/react-with-styles-interface-aphrodite#readme",
   "devDependencies": {
-    "airbnb-js-shims": "^2.1.1",
-    "aphrodite": "^2.1.0",
-    "babel-cli": "^6.26.0",
-    "babel-plugin-transform-replace-object-assign": "^1.0.0",
-    "babel-preset-airbnb": "^2.5.2",
-    "babel-register": "^6.26.0",
-    "chai": "^4.1.2",
-    "eslint": "^5.13.0",
-    "eslint-config-airbnb": "^17.1.0",
-    "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-jsx-a11y": "^6.2.1",
-    "eslint-plugin-react": "^7.12.4",
+    "@babel/cli": "^7.5.5",
+    "@babel/core": "^7.5.5",
+    "@babel/register": "^7.5.5",
+    "airbnb-js-shims": "^2.2.0",
+    "aphrodite": "^2.3.1",
+    "babel-plugin-transform-replace-object-assign": "^2.0.0",
+    "babel-preset-airbnb": "^4.0.1",
+    "chai": "^4.2.0",
+    "eslint": "^5.16.0",
+    "eslint-config-airbnb": "^17.1.1",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-react": "^7.14.3",
     "in-publish": "^2.0.0",
     "mocha": "^5.2.0",
-    "prop-types": "^15.6.2",
-    "react": "^16.4.1",
-    "react-dom": "^16.4.1",
+    "prop-types": "^15.7.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "rimraf": "^2.6.3",
     "safe-publish-latest": "^1.1.2",
     "sinon": "^6.3.5",
-    "sinon-sandbox": "^2.0.0"
+    "sinon-sandbox": "^2.0.5"
   },
   "peerDependencies": {
     "aphrodite": "^2.1.0",
@@ -71,6 +72,6 @@
     "has": "^1.0.3",
     "object.assign": "^4.1.0",
     "object.entries": "^1.1.0",
-    "rtl-css-js": "^1.11.0"
+    "rtl-css-js": "^1.13.0"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
---compilers js:babel-register,jsx:babel-register
+--require @babel/register test/**/*.{js,jsx}
 --require airbnb-js-shims
 --recursive


### PR DESCRIPTION
## Summary

Update all dependencies. We also drop support for `node` versions < 6 since babel dropped support for them in `babel@7`.

**Note**: This is step 2 in a list of TODOs that I have for refactoring this library to not use singletons. While these updates are _not_ necessary, they keep the repo modernized.

- [x] 1. ~Update `react-with-styles` deps~: 
https://github.com/airbnb/react-with-styles/pull/219
- [x] 2. ~Update `react-with-styles-interface-aphrodite` deps~: 
https://github.com/airbnb/react-with-styles-interface-aphrodite/pull/65
- [ ] 3. Update `react-with-styles` to use styles interface and theme in context
- [ ] 4. Publish `react-with-styles v4.0.0`
- [ ] 5. Update the `react-with-styles-interface-aphrodite` peer dep version for `react-with-styles`
- [ ] 6. Publish `react-with-styles-interface-aphrodite v6.0.0`

## Testing

- [x] Ran `npm run build` and `npm run test` using `node@8.9.1` and `npm@6.9.0` with success
- [x] CI tests all the other versions of `node` and `npm` that we support

@brucewpaul @goatslacker 
@ljharb @lencioni 